### PR TITLE
fix: password

### DIFF
--- a/src/ESP01Firmware/ESP01Firmware.ino
+++ b/src/ESP01Firmware/ESP01Firmware.ino
@@ -2,7 +2,7 @@
 #include <WiFiClient.h>
 
 const char *ssid = "PSLab";
-const char *password = "pslab";
+const char *password = "pslab123"; // Empty or 8-63 characters long
 
 WiFiServer server(80);
 


### PR DESCRIPTION
Resolves #4.
Changes the password to _pslab123_, making it between 8-63 characters long and hence valid for the ESP01 chip.

## Summary by Sourcery

Bug Fixes:
- Fix password validation issue for ESP01 chip.