### PR TITLE
chore: updated pipelines to draft releases with exported binaries

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,38 @@
+name-template: 'Release v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: ':rocket: Features and Enhancements'
+    labels:
+      - 'feat'
+      - 'Feature'
+      - 'Enhancement'
+  - title: ':bug: Bug Fixes'
+    label: 'Fix'
+  - title: ':wrench: Maintenance'
+    labels:
+      - 'Chore'
+  - title: ':page_facing_up: Documentation'
+    label: 'Documentation'
+change-template: '- $TITLE (#$NUMBER) - @$AUTHOR'
+exclude-contributors:
+  - 'dependabot'
+  - 'dependabot[bot]'
+exclude-labels:
+  - 'Dependencies'
+  - 'Chore'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |-
+  ## Changes
+  $CHANGES
+  
+  This release was made possible thanks to $CONTRIBUTORS

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -31,3 +33,18 @@ jobs:
             - name: esp8266:esp8266
               source-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
           sketch-paths: src/
+          cli-compile-flags: |
+            - --export-binaries
+
+      - name: Draft Release
+        if: ${{ github.event_name == 'push' }}
+        id: draft-release
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Release Assets
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          gh release upload ${{ steps.draft-release.outputs.tag_name }} src/ESP01Firmware/build/esp8266.esp8266.generic/ESP01Firmware.ino.bin --clobber
+


### PR DESCRIPTION
Fixes #6 

@bessman I've configured the pipelines to export binaries and create **draft** releases with them. We can then update the release body as per ourselves and make a release.

## Summary by Sourcery

Configure pipelines to create draft releases containing exported binaries.

Enhancements:
- Export binaries during compilation.

CI:
- Set up a continuous integration workflow to generate draft releases with binaries attached.