### PR TITLE
fix: minimize timeouts

### DIFF
--- a/src/ESP01Firmware/ESP01Firmware.ino
+++ b/src/ESP01Firmware/ESP01Firmware.ino
@@ -8,6 +8,7 @@ WiFiServer server(80);
 
 void setup() {
   Serial.begin(1000000);
+  Serial.setTimeout(0);
 
   WiFi.setPhyMode(WIFI_PHY_MODE_11N);
 
@@ -20,6 +21,7 @@ void setup() {
 
 void loop() {
   WiFiClient client = server.available();
+  client.setTimeout(0);
 
   if (client) {
     while (client.connected()) {


### PR DESCRIPTION
I set timeouts to 0 in order to increase throughput. I did some measurements (getting oscilloscope data) and in my setup data transfer was up to 20 percent faster. This is not the breakthrough I was hoping for, but it is an improvement.

## Summary by Sourcery

Enhancements:
- Disable timeouts on Serial and WiFiClient connections to reduce communication delays and improve throughput by up to 20%